### PR TITLE
Fallback to COGNITO_* environment variables if no command-line arguments

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4,9 +4,9 @@ import {
   CognitoUser,
   CognitoUserPool,
 } from "amazon-cognito-identity-js";
-import { parseArgs } from "node:util";
+import { parseArgs, ParseArgsConfig } from "node:util";
 
-type CognitoSession = {
+export type CognitoSession = {
   accessToken: string;
   refreshToken: string;
   idToken: string;
@@ -14,31 +14,52 @@ type CognitoSession = {
   issuedAt: number;
 };
 
-type Args = {
+export type Args = {
   username: string;
   password: string;
   clientId: string;
   userPoolId: string;
 };
 
-const parseAndValidateArgs = (): Args => {
-  const {
-    values: { username, password, clientId, userPoolId },
-  } = parseArgs({
-    options: {
-      username: { type: "string" },
-      password: { type: "string" },
-      clientId: { type: "string" },
-      userPoolId: { type: "string" },
-    },
-  });
+const parseArgsConfig: ParseArgsConfig = {
+  options: {
+    username: { type: "string" },
+    password: { type: "string" },
+    clientId: { type: "string" },
+    userPoolId: { type: "string" },
+  },
+};
+
+export const envToArgs = (): string[] =>
+  Object.keys(process.env)
+    .filter((k) =>
+      k.match(/^COGNITO_(CLIENT_ID|PASSWORD|USERNAME|USER_POOL_ID)/),
+    )
+    .map((k) => [
+      k
+        .toLowerCase()
+        .replace(/(cognito)*_/, "--")
+        .replace(/_/g, "")
+        .replace(/id/, "Id")
+        .replace(/pool/, "Pool"),
+      process.env[k] ?? "",
+    ])
+    .flat();
+
+export const parseAndValidateArgs = (args: string[] = envToArgs()): Args => {
+  const { username, password, clientId, userPoolId } = {
+    ...parseArgs({ args, ...parseArgsConfig }).values,
+    ...parseArgs(parseArgsConfig).values,
+  } as Args;
+
   if (username && password && clientId && userPoolId) {
     return { username, password, clientId, userPoolId };
   }
+
   throw new Error("Missing required arguments");
 };
 
-const signIn = async ({
+export const signIn = async ({
   username,
   password,
   clientId,
@@ -74,6 +95,16 @@ const signIn = async ({
 };
 
 const main = async () => {
+  const help = `Sign in to a Cognito user pool using SRP.
+
+Usage:
+
+cognito-srp-sign-in
+  --username <username>
+  --password <password>
+  --clientId <clientId>
+  --userPoolId <userPoolId>
+`;
   try {
     const args = parseAndValidateArgs();
     const session = await signIn(args);
@@ -85,15 +116,6 @@ const main = async () => {
   }
 };
 
-const help = `Sign in to a Cognito user pool using SRP.
-
-Usage:
-
-cognito-srp-sign-in
-  --username <username>
-  --password <password>
-  --clientId <clientId>
-  --userPoolId <userPoolId>
-`;
-
-main();
+if (typeof require !== "undefined" && require.main === module) {
+  main().then(() => {});
+}


### PR DESCRIPTION
Checks for environment variables:

- `COGNITO_USERNAME`
- `COGNITO_PASSWORD`
- `COGNITO_CLIENT_ID`
- `COGNITO_USER_POOL_ID`

Command-line argument values take precedence over environment variable values.